### PR TITLE
chore: drop unnecessary license decisions

### DIFF
--- a/.license-decisions.yml
+++ b/.license-decisions.yml
@@ -83,36 +83,6 @@
     :why:
     :versions: []
     :when: 2022-11-02 21:58:20.530206000 Z
-- - :permit
-  - 0BSD
-  - :who: gabor@opcotech.com
-    :why:
-    :versions: []
-    :when: 2022-12-05 07:08:35.333188000 Z
-- - :permit
-  - Public Domain
-  - :who: gabor@opcotech.com
-    :why:
-    :versions: []
-    :when: 2022-12-05 07:09:35.925375000 Z
-- - :permit
-  - CC-BY-4.0
-  - :who: gabor@opcotech.com
-    :why:
-    :versions: []
-    :when: 2022-12-05 07:11:57.318344000 Z
-- - :permit
-  - CC0-1.0
-  - :who: gabor@opcotech.com
-    :why:
-    :versions: []
-    :when: 2022-12-05 07:12:34.236265000 Z
-- - :permit
-  - Python-2.0
-  - :who: gabor@opcotech.com
-    :why:
-    :versions: []
-    :when: 2022-12-05 07:40:56.058052000 Z
 - - :approve
   - github.com/spf13/afero
   - :who: gabor@opcotech.com

--- a/scripts/extract-and-lint-licenses.sh
+++ b/scripts/extract-and-lint-licenses.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]:-$0}")/../")"
-LICENSE_DECISIONS_FILE="${ROOT_DIR}/assets/license-decisions.yml"
+LICENSE_DECISIONS_FILE="${ROOT_DIR}/.license-decisions.yml"
 
 # The following licenses are not included in the SPDX license list, but are
 # used by some of the dependencies. We need to add them to the license


### PR DESCRIPTION
## Description

This PR drops all unnecessary license decisions to make sure we know what are the licenses we can choose from when we want to open source the project at some point.

## Supporting information

N/A

### Dependencies

N/A

### Screenshots

N/A

## Testing instructions

1. validate `make lint.license` prints out possible licenses

## Other information

N/A

## Checklist

### Documentation

- [x] Documentation comments are updated
- [x] Documentation site is updated

### Code quality

- [x] `make format` has been run
- [x] `make lint` passes
- [x] `make test` passes

### Review

- [x] Self-checked the diff
- [x] Reviewed the code based on Go's [code review guide]
- [x] Reviewed the code based on Go's [concurrency review guide]

### Miscellaneous

- [x] Pull request is rebased onto main
- [x] Commit history is clean


[code review guide]: https://github.com/golang/go/wiki/CodeReviewComments
[concurrency review guide]: https://github.com/golang/go/wiki/CodeReviewConcurrency
