### PR TITLE
chore: parse quotaValue with ParseUint instead of Atoi

### DIFF
--- a/tools/license-generator/main.go
+++ b/tools/license-generator/main.go
@@ -80,7 +80,7 @@ func parseFlags() error {
 			}
 
 			quotaKey := elemoLicense.Quota(quotaParts[0])
-			quotaValue, err := strconv.Atoi(quotaParts[1])
+			quotaValue, err := strconv.ParseUint(quotaParts[1], 10, 32)
 			if err != nil {
 				return errors.New("invalid quota value")
 			}


### PR DESCRIPTION
## Description

Closes #175 

Changes the string to integer conversion from strcov.Atoi to strcov.ParseUint (liek suggested in the issue)

## Supporting information

Link to other information about the change, such as, GitHub issues or documentation.
#175 

### Dependencies

* _List of the dependencies for this change, otherwise write "N/A"_
N/A

### Screenshots

Screenshots if applicable, otherwise, write "N/A".

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Other information

Include other information, such as, which sources and targets are affected.

## Checklist

- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

### Documentation

- Documentation comments are updated
- Documentation site is updated

### Review

- Reviewed the code based on Go's [code review guide]
- Reviewed the code based on Go's [concurrency review guide]

### Miscellaneous

- Pull request is rebased onto main
- Commit history is clean

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/opcotech/elemo/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

[code review guide]: https://github.com/golang/go/wiki/CodeReviewComments

[concurrency review guide]: https://github.com/golang/go/wiki/CodeReviewConcurrency
