### PR TITLE
Use the built-in datetime function for creating and updating resources

### DIFF
--- a/internal/repository/neo4j/attachment.go
+++ b/internal/repository/neo4j/attachment.go
@@ -149,8 +149,8 @@ func (r *AttachmentRepository) Update(ctx context.Context, id model.ID, name str
 	RETURN a, o.id AS o`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"name":       name,
+		"id":   id.String(),
+		"name": name,
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("a", "o"))

--- a/internal/repository/neo4j/attachment.go
+++ b/internal/repository/neo4j/attachment.go
@@ -143,7 +143,7 @@ func (r *AttachmentRepository) Update(ctx context.Context, id model.ID, name str
 
 	cypher := `
 	MATCH (a:` + id.Label() + ` {id: $id})
-	SET a.name = $name, a.updated_at = datetime($updated_at)
+	SET a.name = $name, a.updated_at = datetime()
 	WITH a
 	MATCH (o:` + model.ResourceTypeUser.String() + `)-[:` + EdgeKindCreated.String() + `]->(a)
 	RETURN a, o.id AS o`
@@ -151,7 +151,6 @@ func (r *AttachmentRepository) Update(ctx context.Context, id model.ID, name str
 	params := map[string]any{
 		"id":         id.String(),
 		"name":       name,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("a", "o"))

--- a/internal/repository/neo4j/comment.go
+++ b/internal/repository/neo4j/comment.go
@@ -143,7 +143,7 @@ func (r *CommentRepository) Update(ctx context.Context, id model.ID, content str
 
 	cypher := `
 	MATCH (c:` + id.Label() + ` {id: $id})
-	SET c.content = $content, c.updated_at =  datetime()
+	SET c.content = $content, c.updated_at = datetime()
 	WITH c
 	MATCH (o:` + model.ResourceTypeUser.String() + `)-[:` + EdgeKindCommented.String() + `]->(c)
 	RETURN c, o.id AS o`

--- a/internal/repository/neo4j/comment.go
+++ b/internal/repository/neo4j/comment.go
@@ -149,8 +149,8 @@ func (r *CommentRepository) Update(ctx context.Context, id model.ID, content str
 	RETURN c, o.id AS o`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"content":    content,
+		"id":      id.String(),
+		"content": content,
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("c", "o"))

--- a/internal/repository/neo4j/comment.go
+++ b/internal/repository/neo4j/comment.go
@@ -143,7 +143,7 @@ func (r *CommentRepository) Update(ctx context.Context, id model.ID, content str
 
 	cypher := `
 	MATCH (c:` + id.Label() + ` {id: $id})
-	SET c.content = $content, c.updated_at = datetime($updated_at)
+	SET c.content = $content, c.updated_at =  datetime()
 	WITH c
 	MATCH (o:` + model.ResourceTypeUser.String() + `)-[:` + EdgeKindCommented.String() + `]->(c)
 	RETURN c, o.id AS o`
@@ -151,7 +151,6 @@ func (r *CommentRepository) Update(ctx context.Context, id model.ID, content str
 	params := map[string]any{
 		"id":         id.String(),
 		"content":    content,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("c", "o"))

--- a/internal/repository/neo4j/document.go
+++ b/internal/repository/neo4j/document.go
@@ -199,8 +199,8 @@ func (r *DocumentRepository) Update(ctx context.Context, id model.ID, patch map[
 	RETURN d, c.id AS c, collect(DISTINCT l.id) AS l, collect(DISTINCT comm.id) AS comm, collect(DISTINCT att.id) AS att`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("d", "c", "l", "comm", "att"))

--- a/internal/repository/neo4j/document.go
+++ b/internal/repository/neo4j/document.go
@@ -190,7 +190,7 @@ func (r *DocumentRepository) Update(ctx context.Context, id model.ID, patch map[
 
 	cypher := `
 	MATCH (d:` + id.Label() + ` {id: $id})
-	SET d += $patch, d.updated_at = datetime($updated_at)
+	SET d += $patch, d.updated_at = datetime()
 	WITH d
 	MATCH (c:` + model.ResourceTypeUser.String() + `)-[` + EdgeKindCreated.String() + `]->(d)
 	OPTIONAL MATCH (d)-[:` + EdgeKindHasLabel.String() + `]->(l:` + model.ResourceTypeLabel.String() + `)
@@ -201,7 +201,6 @@ func (r *DocumentRepository) Update(ctx context.Context, id model.ID, patch map[
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	doc, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("d", "c", "l", "comm", "att"))

--- a/internal/repository/neo4j/issue.go
+++ b/internal/repository/neo4j/issue.go
@@ -527,7 +527,7 @@ func (r *IssueRepository) Update(ctx context.Context, id model.ID, patch map[str
 
 	cypher := `
 	MATCH (i:` + id.Label() + ` {id: $id})
-	SET i += $patch, i.updated_at = datetime($updated_at)
+	SET i += $patch, i.updated_at = datetime()
 	WITH i
 	OPTIONAL MATCH (i)-[:` + EdgeKindRelatedTo.String() + ` {kind: $parent_kind}]->(par:` + model.ResourceTypeIssue.String() + `)
 	OPTIONAL MATCH (i)-[:` + EdgeKindRelatedTo.String() + `]->(rel:` + model.ResourceTypeIssue.String() + `)
@@ -545,7 +545,6 @@ func (r *IssueRepository) Update(ctx context.Context, id model.ID, patch map[str
 		"id":          id.String(),
 		"patch":       patch,
 		"parent_kind": model.IssueRelationKindSubtaskOf.String(),
-		"updated_at":  time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	scanParams := &issueScanParams{

--- a/internal/repository/neo4j/label.go
+++ b/internal/repository/neo4j/label.go
@@ -119,8 +119,8 @@ func (r *LabelRepository) Update(ctx context.Context, id model.ID, patch map[str
 	RETURN l`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	label, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("l"))

--- a/internal/repository/neo4j/label.go
+++ b/internal/repository/neo4j/label.go
@@ -115,13 +115,12 @@ func (r *LabelRepository) Update(ctx context.Context, id model.ID, patch map[str
 
 	cypher := `
 	MATCH (l:` + id.Label() + ` {id: $id})
-	SET l += $patch, l.updated_at = datetime($updated_at)
+	SET l += $patch, l.updated_at = datetime()
 	RETURN l`
 
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	label, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("l"))

--- a/internal/repository/neo4j/organization.go
+++ b/internal/repository/neo4j/organization.go
@@ -161,8 +161,8 @@ func (r *OrganizationRepository) Update(ctx context.Context, id model.ID, patch 
 	RETURN o, collect(DISTINCT u.id) AS m, collect(DISTINCT n.id) AS n, collect(DISTINCT t.id) AS t`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	org, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("o", "n", "t", "m"))

--- a/internal/repository/neo4j/organization.go
+++ b/internal/repository/neo4j/organization.go
@@ -153,7 +153,7 @@ func (r *OrganizationRepository) Update(ctx context.Context, id model.ID, patch 
 	defer span.End()
 
 	cypher := `
-	MATCH (o:` + id.Label() + ` {id: $id}) SET o += $patch, o.updated_at = datetime($updated_at)
+	MATCH (o:` + id.Label() + ` {id: $id}) SET o += $patch, o.updated_at = datetime()
 	WITH o
 	OPTIONAL MATCH (u:` + model.ResourceTypeUser.String() + `)-[:` + EdgeKindMemberOf.String() + `]->(o)
 	OPTIONAL MATCH (o)-[:` + EdgeKindHasNamespace.String() + `]->(n:` + model.ResourceTypeNamespace.String() + `)
@@ -163,7 +163,6 @@ func (r *OrganizationRepository) Update(ctx context.Context, id model.ID, patch 
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	org, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("o", "n", "t", "m"))

--- a/internal/repository/neo4j/permission.go
+++ b/internal/repository/neo4j/permission.go
@@ -353,14 +353,13 @@ func (r *PermissionRepository) Update(ctx context.Context, id model.ID, kind mod
 
 	cypher := `
 	MATCH (s)-[p:` + EdgeKindHasPermission.String() + ` {id: $id}]->(t)
-	SET p.kind = $kind, p.updated_at = datetime($updated_at)
+	SET p.kind = $kind, p.updated_at = datetime()
 	RETURN s, p, t
 	`
 
 	params := map[string]any{
 		"id":         id.String(),
 		"kind":       kind.String(),
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	perm, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("p", "s", "t"))

--- a/internal/repository/neo4j/permission.go
+++ b/internal/repository/neo4j/permission.go
@@ -358,8 +358,8 @@ func (r *PermissionRepository) Update(ctx context.Context, id model.ID, kind mod
 	`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"kind":       kind.String(),
+		"id":   id.String(),
+		"kind": kind.String(),
 	}
 
 	perm, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("p", "s", "t"))

--- a/internal/repository/neo4j/project.go
+++ b/internal/repository/neo4j/project.go
@@ -176,7 +176,7 @@ func (r *ProjectRepository) Update(ctx context.Context, id model.ID, patch map[s
 
 	cypher := `
 	MATCH (p:` + id.Label() + ` {id: $id})
-	SET p += $patch, p.updated_at = datetime($updated_at)
+	SET p += $patch, p.updated_at = datetime()
 	WITH p
 	OPTIONAL MATCH (d:` + model.ResourceTypeDocument.String() + `)-[:` + EdgeKindBelongsTo.String() + `]->(p)
 	OPTIONAL MATCH (p)-[:` + EdgeKindHasTeam.String() + `]->(t:` + model.ResourceTypeRole.String() + `)
@@ -186,7 +186,6 @@ func (r *ProjectRepository) Update(ctx context.Context, id model.ID, patch map[s
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	project, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("p", "d", "t", "i"))

--- a/internal/repository/neo4j/project.go
+++ b/internal/repository/neo4j/project.go
@@ -184,8 +184,8 @@ func (r *ProjectRepository) Update(ctx context.Context, id model.ID, patch map[s
 	RETURN p, d, t, i`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	project, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("p", "d", "t", "i"))

--- a/internal/repository/neo4j/role.go
+++ b/internal/repository/neo4j/role.go
@@ -154,7 +154,7 @@ func (r *RoleRepository) Update(ctx context.Context, id, belongsTo model.ID, pat
 
 	cypher := `
 	MATCH (r:` + id.Label() + ` {id: $id}), (b:` + belongsTo.Label() + ` {id: $belongs_to_id})
-	SET r += $patch, r.updated_at = datetime($updated_at)
+	SET r += $patch, r.updated_at = datetime()
 	WITH r
 	OPTIONAL MATCH (r)<-[:` + EdgeKindMemberOf.String() + `]-(u:` + model.ResourceTypeUser.String() + `)
 	OPTIONAL MATCH (r)-[p:` + EdgeKindHasPermission.String() + `]->()
@@ -164,7 +164,6 @@ func (r *RoleRepository) Update(ctx context.Context, id, belongsTo model.ID, pat
 		"id":            id.String(),
 		"belongs_to_id": belongsTo.String(),
 		"patch":         patch,
-		"updated_at":    time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	role, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("r", "m", "p"))

--- a/internal/repository/neo4j/todo.go
+++ b/internal/repository/neo4j/todo.go
@@ -170,8 +170,8 @@ func (r *TodoRepository) Update(ctx context.Context, id model.ID, patch map[stri
 	RETURN t, o.id as o, c.id as c`
 
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	todo, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("t", "o", "c"))

--- a/internal/repository/neo4j/todo.go
+++ b/internal/repository/neo4j/todo.go
@@ -163,7 +163,7 @@ func (r *TodoRepository) Update(ctx context.Context, id model.ID, patch map[stri
 
 	cypher := `
 	MATCH (t:` + id.Label() + ` {id: $id})
-	SET t += $patch, t.updated_at = datetime($updated_at)
+	SET t += $patch, t.updated_at = datetime()
 	WITH t
 	OPTIONAL MATCH (t)-[:` + EdgeKindBelongsTo.String() + `]->(o)
 	OPTIONAL MATCH (t)<-[:` + EdgeKindCreated.String() + `]-(c)
@@ -172,7 +172,6 @@ func (r *TodoRepository) Update(ctx context.Context, id model.ID, patch map[stri
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	todo, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("t", "o", "c"))

--- a/internal/repository/neo4j/user.go
+++ b/internal/repository/neo4j/user.go
@@ -201,8 +201,8 @@ func (r *UserRepository) Update(ctx context.Context, id model.ID, patch map[stri
 	RETURN u, collect(DISTINCT p.id) AS p, collect(DISTINCT d.id) AS d
 	`
 	params := map[string]any{
-		"id":         id.String(),
-		"patch":      patch,
+		"id":    id.String(),
+		"patch": patch,
 	}
 
 	updated, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("u", "p", "d"))

--- a/internal/repository/neo4j/user.go
+++ b/internal/repository/neo4j/user.go
@@ -194,7 +194,7 @@ func (r *UserRepository) Update(ctx context.Context, id model.ID, patch map[stri
 
 	cypher := `
 	MATCH (u:` + id.Label() + ` {id: $id})
-	SET u += $patch, u.updated_at = datetime($updated_at)
+	SET u += $patch, u.updated_at = datetime()
 	WITH u
 	OPTIONAL MATCH (u)-[p:` + EdgeKindHasPermission.String() + `]->()
 	OPTIONAL MATCH (u)<-[r:` + EdgeKindBelongsTo.String() + `]-(d:` + model.ResourceTypeDocument.String() + `)
@@ -203,7 +203,6 @@ func (r *UserRepository) Update(ctx context.Context, id model.ID, patch map[stri
 	params := map[string]any{
 		"id":         id.String(),
 		"patch":      patch,
-		"updated_at": time.Now().UTC().Format(time.RFC3339Nano),
 	}
 
 	updated, err := ExecuteWriteAndReadSingle(ctx, r.db, cypher, params, r.scan("u", "p", "d"))


### PR DESCRIPTION
Close https://github.com/opcotech/elemo/issues/179

## Description

Use Neo4j's datetime() function directly in Cypher queries to automatically generate updated_at timestamps, removing the need to pass this parameter externally.

## Supporting information 

Link to other information about the change, such as, GitHub issues or documentation.

### Dependencies

* _List of the dependencies for this change, otherwise write "N/A"_

### Screenshots

Screenshots if applicable, otherwise, write "N/A".

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Other information

Include other information, such as, which sources and targets are affected.

## Checklist

- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

### Documentation

- Documentation comments are updated
- Documentation site is updated

### Review

- Reviewed the code based on Go's [code review guide]
- Reviewed the code based on Go's [concurrency review guide]

### Miscellaneous

- Pull request is rebased onto main
- Commit history is clean

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/opcotech/elemo/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

[code review guide]: https://github.com/golang/go/wiki/CodeReviewComments

[concurrency review guide]: https://github.com/golang/go/wiki/CodeReviewConcurrency
