### PR TITLE
fix: wrap parameters in Makefile in quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ release: ## Cut a new release
 	$(if $(value RELEASE_VERSION),,$(error No RELEASE_VERSION set))
 
 	$(call log, bumping front-end version)
-	@jq '.version="$(RELEASE_VERSION)"' $(FRONTEND_CLIENT_DIR)/package.json > $(TMPDIR)/package.json.tmp && \
-		mv $(TMPDIR)/package.json.tmp $(FRONTEND_CLIENT_DIR)/package.json;
-	@jq '.version="$(RELEASE_VERSION)"' $(FRONTEND_DIR)/package.json > $(TMPDIR)/package.json.tmp && \
-		mv $(TMPDIR)/package.json.tmp $(FRONTEND_DIR)/package.json;
-	@$(PNPM_EXEC) update --prefix $(FRONTEND_CLIENT)
+	@jq '.version="$(RELEASE_VERSION)"' "$(FRONTEND_CLIENT_DIR)/package.json" > "$(TMPDIR)/package.json.tmp" && \
+		mv "$(TMPDIR)/package.json.tmp" "$(FRONTEND_CLIENT_DIR)/package.json";
+	@jq '.version="$(RELEASE_VERSION)"' "$(FRONTEND_DIR)/package.json" > "$(TMPDIR)/package.json.tmp" && \
+		mv "$(TMPDIR)/package.json.tmp" "$(FRONTEND_DIR)/package.json";
+	@$(PNPM_EXEC) update --prefix "$(FRONTEND_CLIENT)"
 
 	@$(MAKE) changelog;
 	
@@ -72,7 +72,7 @@ generate.server: ## Generate API server
 	@go generate ./...
 
 	$(call log, generating backend API server)
-	@oapi-codegen -config $(API_DIR)/generator.config.yml -o $(API_SERVER_DIR)/server.go $(API_DIR)/openapi.yaml
+	@oapi-codegen -config "$(API_DIR)/generator.config.yml" -o "$(API_SERVER_DIR)/server.go" "$(API_DIR)/openapi.yaml"
 
 .PHONY: generate.client
 generate.client: ## Generate API client
@@ -83,7 +83,7 @@ generate.client: ## Generate API client
 generate.email: ## Generate HTML template emails
 	# TODO: when deployed to production, we should use the actual S3 bucket and endpoint
 	$(call log, compiling email templates)
-	@$(PNPM_EMAILS_RUN) build --out $(TEMPLATES_DIR)/email \
+	@$(PNPM_EMAILS_RUN) build --out "$(TEMPLATES_DIR)/email" \
 		--access-key-id "access-key-id" \
 		--secret-access-key "secret-access-key" \
 		--region "us-east-1" \
@@ -103,8 +103,8 @@ dep.backend: ## Download backend dependencies
 .PHONY: dep.frontend
 dep.frontend: ## Install front-end dependencies
 	$(call log, download and install front-end dependencies)
-	@rm -rf $(FRONTEND_DIR)/node_modules
-	@$(PNPM_EXEC) install --prefix $(FRONTEND_DIR)
+	@rm -rf "$(FRONTEND_DIR)/node_modules"
+	@$(PNPM_EXEC) install --prefix "$(FRONTEND_DIR)"
 
 .PHONY: build
 build: build.backend build.frontend ## Build backend and front-end
@@ -162,24 +162,24 @@ test.backend.bench: ## Run backend benchmarks
 .PHONY: test.backend.unit
 test.backend.unit: ## Run backend unit tests
 	$(call log, execute backend unit tests)
-	@rm -f $(BACKEND_COVER_OUT_UNIT)
-	@$(GO_TEST_COVER) -short -coverprofile=$(BACKEND_COVER_OUT_UNIT) ./...
+	@rm -f "$(BACKEND_COVER_OUT_UNIT)"
+	@$(GO_TEST_COVER) -short -coverprofile="$(BACKEND_COVER_OUT_UNIT)" ./...
 
 .PHONY: test.backend.integration
 test.backend.integration: ## Run backend integration tests
 	$(call log, execute backend integration tests)
 	@rm -f $(BACKEND_COVER_OUT_INTEGRATION)
-	@$(GO_TEST_COVER) -timeout 900s -run=Integration -coverprofile=$(BACKEND_COVER_OUT_INTEGRATION) ./...
+	@$(GO_TEST_COVER) -timeout 900s -run=Integration -coverprofile="$(BACKEND_COVER_OUT_INTEGRATION)" ./...
 
 .PHONY: test.backend.coverage
 test.backend.coverage: ## Combine unit and integration test coverage
 	$(call log, combine backend test coverage)
-	@rm -f $(BACKEND_COVER_OUT)
-	@echo "mode: atomic" > $(BACKEND_COVER_OUT)
-	@for file in $(BACKEND_COVER_OUT_UNIT) $(BACKEND_COVER_OUT_INTEGRATION); do \
-		cat $$file | egrep -v ${GO_TEST_IGNORE} >> $(BACKEND_COVER_OUT); \
+	@rm -f "$(BACKEND_COVER_OUT)"
+	@echo "mode: atomic" > "$(BACKEND_COVER_OUT)"
+	@for file in "$(BACKEND_COVER_OUT_UNIT)" "$(BACKEND_COVER_OUT_INTEGRATION)"; do \
+		cat $$file | egrep -v "${GO_TEST_IGNORE}" >> "$(BACKEND_COVER_OUT)"; \
 	done
-	@rm -f $(BACKEND_COVER_OUT_UNIT) $(BACKEND_COVER_OUT_INTEGRATION)
+	@rm -f "$(BACKEND_COVER_OUT_UNIT)" "$(BACKEND_COVER_OUT_INTEGRATION)"
 	@$(GO_EXEC) tool cover -func "$(BACKEND_COVER_OUT)"
 
 .PHONY: test.frontend
@@ -196,7 +196,7 @@ test.frontend.e2e: ## Run front-end end-to-end tests
 test.k6: ## Run k6 tests
 	$(call log, execute k6 tests)
 	@$(MAKE) start.backend
-	@k6 run $(ROOT_DIR)/tests/main.js
+	@k6 run "$(ROOT_DIR)/tests/main.js"
 	@trap "$(MAKE) stop.backend" EXIT
 
 .PHONY: lint


### PR DESCRIPTION
<!--
Thank you for opening a pull request! 🎉

Before marking the PR ready for review, please make sure that:
- The pull request has a descriptive but not verbose title
- The description links to any existing issues
- The testing instructions are clear
- The code you submit has the necessary documentation
- You complete everything in the "Checklist" section
-->

## Description

This PR wraps `Makefile` parameters in quotes (`"`), so it is not messing with any files if the project's path contains any spaces.

Currently, the `@rm -rf $(FRONTEND_DIR)/node_modules` line in the `Makefile` can delete files unintentionally if the project's absolute path is `C/Some Path/elemo`.

## Dependencies

N/A

## Screenshots

N/A

## Testing instructions

1. In the given OS's temporary directory create a directory with a space in its name
2. Clone the project in the new directory
3. Create some random files (that may be deleted) in the new directory
4. Run `make dep.frontend` and/or `./scripts/setup.sh` in the cloned project dir
5. Verify the random files still exist

## Checklist

- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/opcotech/elemo/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
