### PR TITLE
refactor: improve integration test speed and output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 ROOT_DIR:=$(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR:=$(ROOT_DIR)/build
+SCRIPTS_DIR:=$(ROOT_DIR)/scripts
 TEMPLATES_DIR:=$(ROOT_DIR)/templates
 API_DIR:=$(ROOT_DIR)/api/openapi
 API_SERVER_DIR:=$(ROOT_DIR)/internal/transport/http/api
@@ -21,7 +22,7 @@ PNPM_RUN=$(PNPM_EXEC) run --prefix "$(ROOT_DIR)/web"
 PNPM_EMAILS_RUN=$(PNPM_EXEC) run --prefix "$(ROOT_DIR)/build/email"
 
 GO_EXEC:=$(shell which go)
-GO_TEST_COVER=$(GO_EXEC) test -race -shuffle=on -cover -covermode=atomic -ldflags="-extldflags=-Wl,-ld_classic"
+GO_TEST_COVER=$(GO_EXEC) test -shuffle=on -cover -covermode=atomic -ldflags="-extldflags=-Wl,-ld_classic"
 GO_TEST_IGNORE:=(mode: atomic|testutil|tools|cmd|http\/api)
 
 TMPDIR:=$(shell echo "${TMPDIR:-/tmp}")
@@ -164,13 +165,13 @@ test.backend.bench: ## Run backend benchmarks
 test.backend.unit: ## Run backend unit tests
 	$(call log, execute backend unit tests)
 	@rm -f "$(BACKEND_COVER_OUT_UNIT)"
-	@$(GO_TEST_COVER) -short -coverprofile="$(BACKEND_COVER_OUT_UNIT)" ./...
+	@$(GO_TEST_COVER) -json -race -short -coverprofile="$(BACKEND_COVER_OUT_UNIT)" ./... | $(SCRIPTS_DIR)/pretty-test.sh
 
 .PHONY: test.backend.integration
 test.backend.integration: ## Run backend integration tests
 	$(call log, execute backend integration tests)
 	@rm -f "$(BACKEND_COVER_OUT_INTEGRATION)"
-	@$(GO_TEST_COVER) -timeout 900s -run=Integration -coverprofile="$(BACKEND_COVER_OUT_INTEGRATION)" ./...
+	@$(GO_TEST_COVER) -json -timeout 900s -run=Integration -coverprofile="$(BACKEND_COVER_OUT_INTEGRATION)" ./... | $(SCRIPTS_DIR)/pretty-test.sh
 
 .PHONY: test.backend.coverage
 test.backend.coverage: ## Combine unit and integration test coverage

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,10 +17,15 @@ This script generates development configuration files and key.
 ## generate-frontend-client.sh
 
 Takes the Open API specification in the `api/openapi` directory, and generates
-a Typescript client from it.
+a TypeScript client from it.
+
+## pretty-test.sh
+
+Takes the JSON output of `go test` command and pretty-formats it using `jq` to
+make it more readable.
 
 ## setup.sh
 
-This script prepares the whole development environment. Generates new developer
-configuration, creates certificates, register a new OAuth client, sets the web
-credentials, creates a new user in the database to interact with.
+This script prepares the whole development environment. Generates a new
+developer configuration, creates certificates, register a new OAuth client,
+sets the web credentials, creates a new user in the database to interact with.

--- a/scripts/pretty-test.sh
+++ b/scripts/pretty-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+jq -r '
+  select(.Action == "fail" or .Action == "pass" or .Action == "run" or .Action == "output") |
+  if .Action == "output" and (.Output != null) then
+    # trim trailing newlines, preserve multiline content
+    (.Output | sub("[\n]+$"; ""))
+  elif .Action == "run" and (.Test != null) then
+    "\n\u001b[33mEXECUTING \(.Test)\u001b[0m"
+  elif .Action == "pass" and (.Test == null) then
+    empty
+  else
+    "\(.Action) \(.Test)"
+  end
+'


### PR DESCRIPTION
<!--
Thank you for opening a pull request! 🎉

Before marking the PR ready for review, please make sure that:
- The pull request has a descriptive but not verbose title
- The description links to any existing issues
- The testing instructions are clear
- The code you submit has the necessary documentation
- You complete everything in the "Checklist" section
-->

## Description

The current execution time of integration tests varies between 12-14 minutes, which is really slow. Considering that the output is not verbose enough, it makes the developer experience even worse as the developer has no idea if the tests are still running or stuck.

This PR changes the verbosity of integration and unit tests by switching to JSON output and adding a helper script (`pretty-test.sh`) to re-format the test output into somewhat human-readable. Also, the `-race` flag was removed from integration tests and now applies only to unit tests.

## Dependencies

N/A

## Screenshots

N/A

## Testing instructions

1. Run unit tests
2. Run integration tests
3. Validate improved integration test execution time

## Checklist

- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/opcotech/elemo/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
